### PR TITLE
Upgrade requests to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.0.1
+requests==2.4.0
 simplejson==3.3.1


### PR DESCRIPTION
PR #2 added requests.packages.urllib3.disable_warnings() which was added
in 2.4.0 of requests.

A side note: It's a bad idea to disable SSL warnings. Just add your
self-signed certificate as the the CA file and you're done.
