### PR TITLE
check if metric exists and exit if not

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -71,7 +71,10 @@ def check(host, metric, warning_threshold, critical_threshold,
     except json.JSONDecodeError, e:
         critical('Could not decode JSON', r.content)
 
-    series = [x for x, _ in data[0]['datapoints'] if x is not None]
+    try:
+        series = [x for x, _ in data[0]['datapoints'] if x is not None]
+    except IndexError: # metric does not exist
+        critical('Metric %s not found' % metric)
     if len(series) == 0:
         critical('No data for %s' % metric)
 


### PR DESCRIPTION
When querying non existent metric script fails

```
[]
Traceback (most recent call last):
  File "/usr/lib/nagios/plugins/check_graphite", line 192, in <module>
    authkey=args.authkey)
  File "/usr/lib/nagios/plugins/check_graphite", line 75, in check
    series = [x for x, _ in data[0]['datapoints'] if x is not None]
IndexError: list index out of range
```
